### PR TITLE
New: split meta into distinct categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_STORE
+.idea/

--- a/code/core/models.go
+++ b/code/core/models.go
@@ -26,12 +26,18 @@ type Country struct {
 	PhoneNumbers      []string               `json:"phone_numbers"`
 	Notes             []string               `json:"notes"`
 	RightDrive        bool                   `json:"right_drive"`
-	MetaInfo          []ImageWithDescription `json:"meta_info"`
+	Meta              Meta                   `json:"meta"`
 	BollardsAndExtras BollardsAndExtras      `json:"bollards_and_extras"`
 	SignageAndTraffic SignageAndTraffic      `json:"signage_and_traffic"`
 	AreaCodes         []AreaCode             `json:"area_codes"`
 	UtilityPoles      UtilityPoles           `json:"utility_poles"`
 	Misc              []ImageWithDescription `json:"misc"`
+}
+
+type Meta struct {
+	Car    []ImageWithDescription `json:"car"`
+	Sky    []ImageWithDescription `json:"sky"`
+	Camera []ImageWithDescription `json:"camera"`
 }
 
 type ImageWithDescription struct {

--- a/code/injections/storage/dummy/stored_countries.go
+++ b/code/injections/storage/dummy/stored_countries.go
@@ -20,10 +20,12 @@ var (
 			"Some Argentinian license plates have a distinctive black point in the middle of the plate",
 		},
 		RightDrive: true,
-		MetaInfo: []core.ImageWithDescription{
-			{
-				ImageURL:    "https://calico-cut-geo-tools.s3.amazonaws.com/argentina-meta-1.png",
-				Description: "The google car in Argentina is black. You can see it by panning down.",
+		Meta: core.Meta{
+			Car: []core.ImageWithDescription{
+				{
+					ImageURL:    "https://calico-cut-geo-tools.s3.amazonaws.com/argentina-meta-1.png",
+					Description: "The google car in Argentina is black. You can see it by panning down.",
+				},
 			},
 		},
 		BollardsAndExtras: core.BollardsAndExtras{


### PR DESCRIPTION
NOTE: I've also changed the top-level key to "meta" from "meta_info", as the "_info" postfix felt redundant